### PR TITLE
Add support for interactive variables with various delimiters

### DIFF
--- a/simdem.py
+++ b/simdem.py
@@ -71,7 +71,7 @@ class Environment(object):
         return self.env
 
 class Demo(object):
-    def __init__(self, script_dir = "demo_scripts", filename = "script.md", is_simulation = True, is_automated = False, is_testing = False):
+    def __init__(self, script_dir="demo_scripts", filename="script.md", is_simulation=True, is_automated=False, is_testing=False):
         """Initialize variables"""
         self.filename = filename
         self.script_dir = script_dir

--- a/simdem.py
+++ b/simdem.py
@@ -90,10 +90,8 @@ class Demo(object):
         var_list = []
         for var in all_vars:
             if var.find(".") >= 0:
-                print(var, "has a .")
                 var = var.split('.')[0]
             if var.find("{") >= 0:
-                print(var, "in in {}")
                 var = var.replace("{", "").replace("}", "")
             if var not in self.env.get():
                 var_list.append(var)

--- a/simdem.py
+++ b/simdem.py
@@ -223,6 +223,7 @@ def type_command(demo):
     """
     Displays the command on the screen
     If simulation == True then it will look like someone is typing the command
+    Highlight uninstatiated environment variables
     """
     print(colorama.Fore.WHITE + colorama.Style.BRIGHT, end="")
     end_of_var = 0

--- a/simdem.py
+++ b/simdem.py
@@ -227,19 +227,22 @@ def type_command(demo):
     If simulation == True then it will look like someone is typing the command
     """
     print(colorama.Fore.WHITE + colorama.Style.BRIGHT, end="")
-    interactive_var = False
+    end_of_var = 0
     current_command, var_list = demo.get_current_command()
     for idx, char in enumerate(current_command):
-        # If we come across a '$', check the var_list list to see if the index
-        # of any of the undefined env vars minus one (to match '$') within
-        # the command matches the index of '$'. If true, start highlighting
-        # the undefined env var.
-        # TODO: Refactor the list comprehension
-        if char == "$" and var_list and idx in [current_command.find(i)-1 for i in var_list if current_command.find(i) > 0]:
-            interactive_var = True
-            print(colorama.Fore.YELLOW + colorama.Style.BRIGHT, end="")
-        if char == " " and interactive_var:
-            interactive_var = False
+        if char == "$" and var_list:
+            for var in var_list:
+                var_idx = current_command.find(var)
+                if var_idx - 1 == idx:
+                    end_of_var = idx + len(var)
+                    print(colorama.Fore.YELLOW + colorama.Style.BRIGHT, end="")
+                    break
+                elif var_idx - 2 == idx and current_command[var_idx - 1] == "{":
+                    end_of_var = idx + len(var) + 1
+                    print(colorama.Fore.YELLOW + colorama.Style.BRIGHT, end="")
+                    break
+        if end_of_var and idx == end_of_var:
+            end_of_var = 0
             print(colorama.Fore.WHITE + colorama.Style.BRIGHT, end="")
         if char != "\n":
             print(char, end="", flush=True)


### PR DESCRIPTION
This PR addresses https://github.com/rgardler/simdem/issues/11 and https://github.com/rgardler/simdem/issues/12

1. Implements a new `get_current_command` function in the `Demo` class that returns a tuple of values, the first of which being the current command and the latter a list of all environment variables that have not been initialized
2. Refactors code to be more readable
3. Adds support for multiple delimiters (" ", ".", "{}")